### PR TITLE
Work around for out-of-bounds read

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ CFLAGS += -std=c99 `pkg-config libpng --cflags`
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 dssim: $(SOURCES) main.c
-	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
+	$(CC) -o $@ $^ $(CFLAGS) $(LIBS) -lm -lz

--- a/dssim.c
+++ b/dssim.c
@@ -161,7 +161,9 @@ static void transposing_1d_blur(LABA *restrict src,
         // blur with left side outside line
         for (int i = 0; i < size; i++) {
             LABA_OP1(sum, -=, row[0]);
-            LABA_OP1(sum, +=, row[i + size]);
+            if((i + size) < width){
+                LABA_OP1(sum, +=, row[i + size]);
+            }
 
             LABA_OPC(dst[i * height + j], sum, /, sizef * 2.0f);
         }
@@ -175,7 +177,9 @@ static void transposing_1d_blur(LABA *restrict src,
 
         // blur with right side outside line
         for (int i = width - size; i < width; i++) {
-            LABA_OP1(sum, -=, row[i - size]);
+            if(i-size >= 0){
+                LABA_OP1(sum, -=, row[i - size]);
+            }
             LABA_OP1(sum, +=, row[width - 1]);
 
             LABA_OPC(dst[i * height + j], sum, /, sizef * 2.0f);


### PR DESCRIPTION
Following https://github.com/pornel/dssim/issues/2 I've ran dssim under valgrind and discovered a couple of out-of-bound reads that in fact were the cause of the negative DSSIM score.
I've worked around them here by adding a bounds test before reading.
Since I'm not familiar with the code, there may be a more elegant way to resolve these issues, but this one seems to work.
I no longer get negative DSSIM scores, and the PNGs in question get a DSSIM score of 0, as they should.

I also added a couple of library flags required for linking to pass in Ubuntu 12.04.
