### PR TITLE
Fix build with gcc8

### DIFF
--- a/src/dssim.c
+++ b/src/dssim.c
@@ -301,7 +301,7 @@ static void regular_1d_blur(const dssim_px_t *src, dssim_px_t *restrict tmp1, ds
 /*
  * blurs (approximate of gaussian)
  */
-static void blur(const dssim_px_t *restrict src, dssim_px_t *restrict tmp, dssim_px_t *restrict dst,
+static void blur(const dssim_px_t *restrict src, dssim_px_t *restrict tmp, dssim_px_t *dst,
                  const int width, const int height)
 {
     assert(src);


### PR DESCRIPTION
Fails with:

    ../subprojects/dssim/src/dssim.c: In function ‘dssim_preprocess_channel’:
    ../subprojects/dssim/src/dssim.c:629:34: error: passing argument 3 to restrict-qualified parameter aliases with argument 1 [-Werror=restrict]
            blur(chan->img, tmp, chan->img, width, height);
                ~~~~~~~~~       ~~~~^~~~~
    ../subprojects/dssim/src/dssim.c:639:38: error: passing argument 3 to restrict-qualified parameter aliases with argument 1 [-Werror=restrict]
        blur(chan->img_sq_blur, tmp, chan->img_sq_blur, width, height);
            ~~~~~~~~~~~~~~~~~       ~~~~^~~~~~~~~~~~~
    ../subprojects/dssim/src/dssim.c: In function ‘get_img1_img2_blur’:
    ../subprojects/dssim/src/dssim.c:657:5: error: passing argument 3 to restrict-qualified parameter aliases with argument 1 [-Werror=restrict]
        blur(img2, tmp, img2, width, height);
        ^~~~