### PR TITLE
Allow passing modified_image as a reference

### DIFF
--- a/src/dssim.rs
+++ b/src/dssim.rs
@@ -418,12 +418,14 @@ fn png_compare() {
 
     let sub_img1 = d.create_image(&Img::new(buf1, file1.width, file1.height).sub_image(2,3,44,33)).unwrap();
     let sub_img2 = d.create_image(&Img::new(buf2, file2.width, file2.height).sub_image(17,9,44,33)).unwrap();
+    // Test passing second image directly
     let (res, _) = d.compare(&sub_img1, sub_img2);
     assert!(res > 0.1);
 
     let sub_img1 = d.create_image(&Img::new(buf1, file1.width, file1.height).sub_image(22,8,61,40)).unwrap();
     let sub_img2 = d.create_image(&Img::new(buf2, file2.width, file2.height).sub_image(22,8,61,40)).unwrap();
-    let (res, _) = d.compare(&sub_img1, sub_img2);
+    // Test passing second image as reference
+    let (res, _) = d.compare(&sub_img1, &sub_img2);
     assert!(res < 0.01);
 }
 


### PR DESCRIPTION
Being forced to move an image for comparison was quite inconvenient, as I intended to reuse them several times. As far as I can tell, though, comparisons shouldn't ever need to modify either input, so a reference should be fine.

The borrow gymnastics are necessary to maximize backwards compatibility. Changing function signatures always introduces the possibility of breaking some obscure use case, but I think this qualifies as [generalizing to generics](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md#minor-change-generalizing-to-generics-1).

I wasn't sure how best to include this in the tests, so I just slightly modified one of the tests to ensure both forms are used.

*Note:* I'm not familiar at all with the codebase! I just changed the signature for `compare()` and let the compiler guide me.