### PR TITLE
Increase to 8 precision of DSSIM displayed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ fn main() {
 
         let (dssim, ssim_maps) = attr.compare(&original, modified);
 
-        println!("{:.6}\t{}", dssim, file2.display());
+        println!("{:.8}\t{}", dssim, file2.display());
 
         if map_output_file.is_some() {
             ssim_maps.par_iter().enumerate().for_each(|(n, map_meta)| {

--- a/src/val.rs
+++ b/src/val.rs
@@ -20,7 +20,7 @@ impl Dssim {
 
 impl fmt::Display for Dssim {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(fmt, "{:.6}", self.0)
+        write!(fmt, "{:.*}", fmt.precision().unwrap_or(6), self.0)
     }
 }
 


### PR DESCRIPTION
Also propagate formatter precision value into `Dssim.fmt()` implementation.