### PR TITLE
Fix borrowing of dst as mutable

### DIFF
--- a/src/blur.rs
+++ b/src/blur.rs
@@ -115,7 +115,7 @@ mod portable {
         do_blur(tmp_src, dst);
     }
 
-    pub fn do_blur(src: ImgRef<f32>, dst: ImgRefMut<f32>) {
+    pub fn do_blur(src: ImgRef<f32>, mut dst: ImgRefMut<f32>) {
         assert_eq!(src.width(), dst.width());
         assert_eq!(src.height(), dst.height());
         assert!(src.width() > 0);


### PR DESCRIPTION
Need to mark in `do_blur()` params so call to `buf_mut()` works.

Sorry! Thought I'd included this in https://github.com/kornelski/dssim/commit/9bc5faa5ab762c6ffa28ff528ffa143ab92e3249 but didn't make it to the PR.