### PR TITLE
[1.x branch] Unbreak JPEG build on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ CFLAGS += -std=c99 `pkg-config libpng --cflags || pkg-config libpng16 --cflags` 
 
 
 ifdef USE_LIBJPEG
-LDFLAGS += -ljpeg
-CFLAGS += -DUSE_LIBJPEG
+CFLAGS += -DUSE_LIBJPEG `pkg-config libjpeg --cflags 2>/dev/null`
+LDFLAGS += `pkg-config libjpeg --libs 2>/dev/null || echo -ljpeg`
 endif
  
 LDFLAGS += `pkg-config libpng --libs || pkg-config libpng16 --libs` -lm -lz $(LDFLAGSADD)

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project ('dssim', 'C',
   version : '1.3.2.1',
-  meson_version : '>= 0.35.0',
+  meson_version : '>= 0.48.0',
   default_options : [ 'warning_level=1'])
 
 dssim_lib_sources = ['src/dssim.c']
@@ -19,6 +19,11 @@ c_args = ['-DNDEBUG',
 cc = meson.get_compiler('c')
 mathlib = cc.find_library('m')
 zlib = cc.find_library('z')
+
+jpeg_dep = dependency('libjpeg', required: get_option('jpeg'))
+if jpeg_dep.found()
+  add_project_arguments('-DUSE_LIBJPEG', language: 'c')
+endif
 
 libdssim = shared_library('dssim-lib',
               dssim_lib_sources,
@@ -45,5 +50,5 @@ executable = executable ('dssim',
              dssim_sources,
              install: true,
              c_args: c_args,
-             dependencies: [png_dep],
+             dependencies: [jpeg_dep, png_dep],
              link_with: [libdssim])

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('jpeg', type: 'feature', value: 'auto', description: 'JPEG support')


### PR DESCRIPTION
Minor convenience for targets not supported by Rust compiler (e.g., FreeBSD 32bit mips, sparc64, riscv64) or relying on C API (cargo-c creates dssim.h/libdssim.so but there're no bindings).
```
$ gmake USE_LIBJPEG=1
cc -Wall -I. -DNDEBUG -O3 -fstrict-aliasing -ffast-math -funroll-loops -fomit-frame-pointer -ffinite-math-only -std=c99 `pkg-config libpng --cflags || pkg-config libpng16 --cflags`  -DUSE_LIBJPEG -c -o src/dssim.o src/dssim.c
cc -Wall -I. -DNDEBUG -O3 -fstrict-aliasing -ffast-math -funroll-loops -fomit-frame-pointer -ffinite-math-only -std=c99 `pkg-config libpng --cflags || pkg-config libpng16 --cflags`  -DUSE_LIBJPEG -c -o src/rwpng.o src/rwpng.c
cc -Wall -I. -DNDEBUG -O3 -fstrict-aliasing -ffast-math -funroll-loops -fomit-frame-pointer -ffinite-math-only -std=c99 `pkg-config libpng --cflags || pkg-config libpng16 --cflags`  -DUSE_LIBJPEG   -c -o src/main.o src/main.c
src/main.c:35:21: error: jpeglib.h: No such file or directory
src/main.c: In function 'read_image_jpeg':
src/main.c:42: error: storage size of 'cinfo' isn't known
src/main.c:43: error: storage size of 'jerr' isn't known
src/main.c:44: warning: implicit declaration of function 'jpeg_std_error'
src/main.c:45: warning: implicit declaration of function 'jpeg_create_decompress'
src/main.c:48: warning: implicit declaration of function 'jpeg_stdio_src'
src/main.c:49: warning: implicit declaration of function 'jpeg_read_header'
src/main.c:49: error: 'TRUE' undeclared (first use in this function)
src/main.c:49: error: (Each undeclared identifier is reported only once
src/main.c:49: error: for each function it appears in.)
src/main.c:53: error: 'JCS_RGB' undeclared (first use in this function)
src/main.c:54: warning: implicit declaration of function 'jpeg_start_decompress'
src/main.c:78: warning: implicit declaration of function 'jpeg_read_scanlines'
src/main.c:100: warning: implicit declaration of function 'jpeg_destroy_decompress'
src/main.c:43: warning: unused variable 'jerr'
src/main.c:42: warning: unused variable 'cinfo'
gmake: *** [<builtin>: src/main.o] Error 1
```
