### PR TITLE
meson: add version check for libpng 1.4+

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,7 +45,7 @@ pkg.generate(libraries : libdssim,
              version : meson.project_version(),
              description : 'A structural similarity library.')
 
-png_dep = dependency('libpng')
+png_dep = dependency('libpng', version: '>=1.4')
 executable = executable ('dssim',
              dssim_sources,
              install: true,


### PR DESCRIPTION
libpng version 1.4+ is really required as also suggested in the code:

```
  src/rwpng.c:#error "Legacy libpng versions are not supported. Please use libpng 1.4+ (1.6+ recommended)."
```

Add the version requirement to the png dependency.

For instance this will make configuration fail early on on older system
where libpng12-dev is installed by default, like Ubuntu 16.04, and
hopefully prompt the user to install libpng16-dev instead without having
to decipher compilation failures, like:

```
-----------------------------------------------------------------------
gcc-9 -Isubprojects/dssim/dssim.p -Isubprojects/dssim -I../subprojects/dssim -I/usr/include/libpng12 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -DNDEBUG -fstrict-aliasing -ffast-math -funroll-loops -fomit-frame-pointer -ffinite-math-only -Wall -std=c99 -MD -MQ subprojects/dssim/dssim.p/src_main.c.o -MF subprojects/dssim/dssim.p/src_main.c.o.d -o subprojects/dssim/dssim.p/src_main.c.o -c ../subprojects/dssim/src/main.c

In file included from /usr/include/libpng12/png.h:321,
                 from ../subprojects/dssim/src/main.c:27:
/usr/include/libpng12/pngconf.h:383:21: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘.’ token
  383 |            __pngconf.h__ in libpng already includes setjmp.h;
      |                     ^
/usr/include/libpng12/pngconf.h:384:12: error: unknown type name ‘__dont__’
  384 |            __dont__ include it again.;
      |            ^~~~~~~~
/usr/include/libpng12/pngconf.h:384:29: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘it’
  384 |            __dont__ include it again.;
      |                             ^~
/usr/include/libpng12/pngconf.h:384:29: error: unknown type name ‘it’; did you mean ‘int’?
  384 |            __dont__ include it again.;
      |                             ^~
      |                             int
-----------------------------------------------------------------------
```