### PR TITLE
chore(deps): revert `cc` crate to 1.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.8"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0cf6e91fde44c773c6ee7ec6bba798504641a8bc2eb7e37a04ffbf4dfaa55a"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "jobserver",
  "libc",


### PR DESCRIPTION
seeing some homebrew build issue with cc 1.2.8

```
  warning: lcms2-sys@4.0.5: ToolExecError: Command env -u IPHONEOS_DEPLOYMENT_TARGET LC_ALL="C" "clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=arm64-apple-macosx15.2" "-I" "vendor/include" "-Wall" "-Wextra" "-DNDEBUG=1" "-o" "/private/tmp/dssim-20250111-7672-dgt5rs/dssim-3.3.4/target/release/build/lcms2-sys-b35959da7780771a/out/49c72391db7e6a2b-cmsalpha.o" "-c" "--" "vendor/src/cmsalpha.c" with args clang did not execute successfully (status code exit status: 1).cargo:warning=clang: error: no such file or directory: '-isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk'
```

relates to:
- https://github.com/Homebrew/homebrew-core/pull/203934
- https://github.com/rust-lang/cc-rs/issues/1362