### PR TITLE
fix: compilation under --no-default-features

### DIFF
--- a/dssim-core/src/lieon.rs
+++ b/dssim-core/src/lieon.rs
@@ -11,6 +11,8 @@ pub mod prelude {
 
 pub trait ParIterator: Sized {
     fn with_min_len(self, _one: usize) -> Self { self }
+    fn with_max_len(self, _one: usize) -> Self { self }
+    fn par_bridge(self) -> Self { self }
 }
 
 impl<T: Iterator> ParIterator for T {


### PR DESCRIPTION
`cargo test --no-default-features` has become broken, at least inside `dssim-core`.

Fix most of it by updating `lieon`, but I couldn't get the `flat_map_iter` stuff to work, so replace it with a boring serial implementation (that hopefully the compiler will vectorise for us? Hah!).
